### PR TITLE
Don't set Content-Length.

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,7 +57,6 @@ var handleCredentials = Meteor.bindEnvironment(function (req, res) {
 
     res.writeHead(200, {
       "Content-Type": "application/json",
-      "Content-Length": text.length
     });
     res.end(text);
   } catch (err) {


### PR DESCRIPTION
The Content-Length header specifies the size of the response body in bytes. `text.length` gives the number of characters in `text`. These values happen to coincide when `text` is composed entirely of ASCII characters. However, if a user has a name like "☆☺☆☺☆☺☆☺☆☺", the mismatch triggers a 500 error and the user does not get automatically logged in.

This patch fixes the problem.