### PR TITLE
Ensure Meteor.loggingIn() is always correct.

### DIFF
--- a/client.js
+++ b/client.js
@@ -22,13 +22,20 @@
 Meteor.startup(function () {
   Deps.autorun(function () {
     if (!Meteor.userId()) {
+      // Accounts._setLoggingIn is a semi-private function, but it's also used in accounts-password.
+      Accounts._setLoggingIn(true);
       HTTP.get("/.sandstorm-credentials", function (error, result) {
         if (error) {
+          Accounts._setLoggingIn(false);
           console.error(error.stack);
         } else if (!result.data) {
+          Accounts._setLoggingIn(false);
           console.error("/.sandstorm-credentials is not JSON?");
         } else if (result.data.token) {
+          // Don't call Accounts._setLoggingIn here and let the normal login flow take over.
           Meteor.loginWithToken(result.data.token, function() {});
+        } else {
+          Accounts._setLoggingIn(false);
         }
       });
     }


### PR DESCRIPTION
Fixes #7 

@jacksingleton let me know if this works for you. `loggingIn()` should always be in the correct state now, and you should be able to tell a non-logged in user by doing `!Meteor.userId() && !Meteor.loggingIn()` (this should also work outside of Sandstorm).