### PR TITLE
Conditionally load the package based on Meteor settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,17 @@ package repository:
 To package a Meteor app for Sandstorm,
 [use the `meteor-spk` tool](https://github.com/sandstorm-io/meteor-spk).
 
-To enable it, Meteor settings should have the following key:
+To enable it, you have to run Meteor with `SANDSTORM` environment variable set:
 
-```json
-{
-  "public": {
-    "sandstorm": true
-  }
-}
+```
+SANDSTORM=1 meteor
 ```
 
 You can set it by adding the following value to `environ` of your command
 in your `sandstorm-pkgdef.capnp`:
 
 ```
-(key = "METEOR_SETTINGS", value = "{\"public\": {\"sandstorm\": true}}"),
+(key = "SANDSTORM", value = "1"),
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ package repository:
 To package a Meteor app for Sandstorm,
 [use the `meteor-spk` tool](https://github.com/sandstorm-io/meteor-spk).
 
+To enable it, Meteor settings should have the following key:
+
+```json
+{
+  "public": {
+    "sandstorm": true
+  }
+}
+```
+
+You can set it by adding the following value to `environ` of your command
+in your `sandstorm-pkgdef.capnp`:
+
+```
+(key = "METEOR_SETTINGS", value = "{\"public\": {\"sandstorm\": true}}"),
+```
+
 ## Usage
 
 * On the client, call `Meteor.sandstormUser()`. (This is a reactive data source.)

--- a/client.js
+++ b/client.js
@@ -152,7 +152,7 @@ function loginWithSandstorm(connection) {
   if (stopImmediately) handle.stop();
 }
 
-if (Meteor.settings && Meteor.settings.public && Meteor.settings.public.sandstorm) {
+if (__meteor_runtime_config__.SANDSTORM) {
   // Auto-login the main Meteor connection.
   loginWithSandstorm(Meteor.connection);
 

--- a/client.js
+++ b/client.js
@@ -125,7 +125,7 @@ function loginWithSandstorm(connection) {
         }
       }
     });
-  }
+  };
 
   // Wait until the connection is up before we start trying to send XHRs.
   var stopImmediately = false;  // Unfortunately, Tracker.autorun() runs the first time inline.
@@ -152,24 +152,26 @@ function loginWithSandstorm(connection) {
   if (stopImmediately) handle.stop();
 }
 
-// Auto-login the main Meteor connection.
-loginWithSandstorm(Meteor.connection);
+if (Meteor.settings.public.sandstorm) {
+  // Auto-login the main Meteor connection.
+  loginWithSandstorm(Meteor.connection);
 
-if (Package["accounts-base"]) {
-  // Make Meteor.loggingIn() work by calling a private method of accounts-base. If this breaks then
-  // maybe we should just overwrite Meteor.loggingIn() instead.
-  Tracker.autorun(function () {
-    Package["accounts-base"].Accounts._setLoggingIn(!Meteor.connection.sandstormUser());
-  });
-}
-
-Meteor.sandstormUser = function () {
-  return Meteor.connection.sandstormUser();
-}
-
-SandstormAccounts = {
-  setTestUserInfo: function (info) {
-    localStorage.sandstormTestUserInfo = JSON.stringify(info);
-    loginWithSandstorm(Meteor.connection);
+  if (Package["accounts-base"]) {
+    // Make Meteor.loggingIn() work by calling a private method of accounts-base. If this breaks then
+    // maybe we should just overwrite Meteor.loggingIn() instead.
+    Tracker.autorun(function () {
+      Package["accounts-base"].Accounts._setLoggingIn(!Meteor.connection.sandstormUser());
+    });
   }
-};
+
+  Meteor.sandstormUser = function () {
+    return Meteor.connection.sandstormUser();
+  };
+
+  SandstormAccounts = {
+    setTestUserInfo: function (info) {
+      localStorage.sandstormTestUserInfo = JSON.stringify(info);
+      loginWithSandstorm(Meteor.connection);
+    }
+  };
+}

--- a/client.js
+++ b/client.js
@@ -152,7 +152,7 @@ function loginWithSandstorm(connection) {
   if (stopImmediately) handle.stop();
 }
 
-if (Meteor.settings.public.sandstorm) {
+if (Meteor.settings && Meteor.settings.public && Meteor.settings.public.sandstorm) {
   // Auto-login the main Meteor connection.
   loginWithSandstorm(Meteor.connection);
 

--- a/server.js
+++ b/server.js
@@ -19,7 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-if (Meteor.settings && Meteor.settings.public && Meteor.settings.public.sandstorm) {
+if (process.env.SANDSTORM) {
+  __meteor_runtime_config__.SANDSTORM = true;
+}
+
+if (__meteor_runtime_config__.SANDSTORM) {
   var Future = Npm.require("fibers/future");
 
   var inMeteor = Meteor.bindEnvironment(function (callback) {

--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-if (Meteor.settings.public.sandstorm) {
+if (Meteor.settings && Meteor.settings.public && Meteor.settings.public.sandstorm) {
   var Future = Npm.require("fibers/future");
 
   var inMeteor = Meteor.bindEnvironment(function (callback) {

--- a/server.js
+++ b/server.js
@@ -19,147 +19,149 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-var Future = Npm.require("fibers/future");
+if (Meteor.settings.public.sandstorm) {
+  var Future = Npm.require("fibers/future");
 
-var inMeteor = Meteor.bindEnvironment(function (callback) {
-  callback();
-});
+  var inMeteor = Meteor.bindEnvironment(function (callback) {
+    callback();
+  });
 
-var logins = {};
-// Maps tokens to currently-waiting login method calls.
+  var logins = {};
+  // Maps tokens to currently-waiting login method calls.
 
-if (Package["accounts-base"]) {
-  Meteor.users._ensureIndex("services.sandstorm.id", { unique: 1, sparse: 1 });
-}
+  if (Package["accounts-base"]) {
+    Meteor.users._ensureIndex("services.sandstorm.id", {unique: 1, sparse: 1});
+  }
 
-Meteor.onConnection(function (connection) {
-  connection._sandstormUser = null;
-  connection.sandstormUser = function () {
-    if (!connection._sandstormUser) {
-      throw new Meteor.Error(400, "Client did not complete authentication handshake.");
+  Meteor.onConnection(function (connection) {
+    connection._sandstormUser = null;
+    connection.sandstormUser = function () {
+      if (!connection._sandstormUser) {
+        throw new Meteor.Error(400, "Client did not complete authentication handshake.");
+      }
+      return this._sandstormUser;
+    };
+  });
+
+  Meteor.methods({
+    loginWithSandstorm: function (token) {
+      check(token, String);
+
+      var future = new Future();
+
+      logins[token] = future;
+
+      var timeout = setTimeout(function () {
+        future.throw(new Meteor.Error("timeout", "Gave up waiting for login rendezvous XHR."));
+      }, 10000);
+
+      var info = future.wait();
+
+      clearTimeout(timeout);
+
+      delete logins[token];
+
+      // Set connection info. The call to setUserId() resets all publishes. We update the
+      // connection's sandstorm info first so that when the publishes are re-run they'll see the
+      // new info. In theory we really want to update it exactly when this.userId is updated, but
+      // we'd have to dig into Meteor internals to pull that off. Probably updating it a little
+      // early is fine?
+      //
+      // Note that calling setUserId() with the same ID a second time still goes through the motions
+      // of restarting all subscriptions, which is important if the permissions changed. Hopefully
+      // Meteor won't decide to "optimize" this by returning early if the user ID hasn't changed.
+      this.connection._sandstormUser = info.sandstorm;
+      this.setUserId(info.userId);
+
+      return info;
     }
-    return this._sandstormUser;
-  };
-});
+  });
 
-Meteor.methods({
-  loginWithSandstorm: function (token) {
-    check(token, String);
+  WebApp.rawConnectHandlers.use(function (req, res, next) {
+    if (req.url === "/.sandstorm-login") {
+      handlePostToken(req, res);
+      return;
+    }
+    return next();
+  });
 
+  function readAll(stream) {
     var future = new Future();
 
-    logins[token] = future;
+    var chunks = [];
+    stream.on("data", function (chunk) {
+      chunks.push(chunk.toString());
+    });
+    stream.on("error", function (err) {
+      future.throw(err);
+    });
+    stream.on("end", function () {
+      future.return();
+    });
 
-    var timeout = setTimeout(function () {
-      future.throw(new Meteor.Error("timeout", "Gave up waiting for login rendezvous XHR."));
-    }, 10000);
+    future.wait();
 
-    var info = future.wait();
-
-    clearTimeout(timeout);
-
-    delete logins[token];
-
-    // Set connection info. The call to setUserId() resets all publishes. We update the
-    // connection's sandstorm info first so that when the publishes are re-run they'll see the
-    // new info. In theory we really want to update it exactly when this.userId is updated, but
-    // we'd have to dig into Meteor internals to pull that off. Probably updating it a little
-    // early is fine?
-    //
-    // Note that calling setUserId() with the same ID a second time still goes through the motions
-    // of restarting all subscriptions, which is important if the permissions changed. Hopefully
-    // Meteor won't decide to "optimize" this by returning early if the user ID hasn't changed.
-    this.connection._sandstormUser = info.sandstorm;
-    this.setUserId(info.userId);
-
-    return info;
+    return chunks.join("");
   }
-});
 
-WebApp.rawConnectHandlers.use(function (req, res, next) {
-  if (req.url === "/.sandstorm-login") {
-    handlePostToken(req, res);
-    return;
-  }
-  return next();
-});
-
-function readAll(stream) {
-  var future = new Future();
-
-  var chunks = [];
-  stream.on("data", function (chunk) {
-    chunks.push(chunk.toString());
-  });
-  stream.on("error", function (err) {
-    future.throw(err);
-  });
-  stream.on("end", function () {
-    future.return();
-  });
-
-  future.wait();
-
-  return chunks.join("");
-}
-
-var handlePostToken = Meteor.bindEnvironment(function (req, res) {
-  inMeteor(function () {
-    try {
-      // Note that cross-origin POSTs cannot set arbitrary Content-Types without explicit CORS
-      // permission, so this effectively prevents XSRF.
-      if (req.headers["content-type"] !== "application/x-sandstorm-login-token") {
-        throw new Error("wrong Content-Type for .sandstorm-login: " + req.headers["content-type"]);
-      }
-
-      var token = readAll(req);
-
-      var future = logins[token];
-      if (!future) {
-        throw new Error("no current login request matching token");
-      }
-
-      var permissions = req.headers["x-sandstorm-permissions"];
-      if (permissions && permissions !== "") {
-        permissions = permissions.split(",");
-      } else {
-        permissions = [];
-      }
-
-      var sandstormInfo = {
-        id: req.headers["x-sandstorm-user-id"] || null,
-        name: decodeURI(req.headers["x-sandstorm-username"]),
-        permissions: permissions,
-        picture: req.headers["x-sandstorm-user-picture"] || null,
-        preferredHandle: req.headers["x-sandstorm-preferred-handle"] || null,
-        pronouns: req.headers["x-sandstorm-user-pronouns"] || null
-      };
-
-      var userInfo = {sandstorm: sandstormInfo};
-      if (Package["accounts-base"]) {
-        if (sandstormInfo.id) {
-          // The user is logged into Sansdtorm. Create a Meteor account for them, or find the
-          // existing one, and record the user ID.
-          var login = Package["accounts-base"].Accounts.updateOrCreateUserFromExternalService(
-              "sandstorm", sandstormInfo, { profile: { name: sandstormInfo.name } });
-          userInfo.userId = login.userId;
-        } else {
-          userInfo.userId = null;
+  var handlePostToken = Meteor.bindEnvironment(function (req, res) {
+    inMeteor(function () {
+      try {
+        // Note that cross-origin POSTs cannot set arbitrary Content-Types without explicit CORS
+        // permission, so this effectively prevents XSRF.
+        if (req.headers["content-type"] !== "application/x-sandstorm-login-token") {
+          throw new Error("wrong Content-Type for .sandstorm-login: " + req.headers["content-type"]);
         }
-      } else {
-        // Since the app isn't using regular Meteor accounts, we can define Meteor.userId()
-        // however we want.
-        userInfo.userId = sandstormInfo.id;
-      }
 
-      future.return(userInfo);
-      res.writeHead(204, {});
-      res.end();
-    } catch (err) {
-      res.writeHead(500, {
-        "Content-Type": "text/plain"
-      });
-      res.end(err.stack);
-    }
+        var token = readAll(req);
+
+        var future = logins[token];
+        if (!future) {
+          throw new Error("no current login request matching token");
+        }
+
+        var permissions = req.headers["x-sandstorm-permissions"];
+        if (permissions && permissions !== "") {
+          permissions = permissions.split(",");
+        } else {
+          permissions = [];
+        }
+
+        var sandstormInfo = {
+          id: req.headers["x-sandstorm-user-id"] || null,
+          name: decodeURI(req.headers["x-sandstorm-username"]),
+          permissions: permissions,
+          picture: req.headers["x-sandstorm-user-picture"] || null,
+          preferredHandle: req.headers["x-sandstorm-preferred-handle"] || null,
+          pronouns: req.headers["x-sandstorm-user-pronouns"] || null
+        };
+
+        var userInfo = {sandstorm: sandstormInfo};
+        if (Package["accounts-base"]) {
+          if (sandstormInfo.id) {
+            // The user is logged into Sansdtorm. Create a Meteor account for them, or find the
+            // existing one, and record the user ID.
+            var login = Package["accounts-base"].Accounts.updateOrCreateUserFromExternalService(
+              "sandstorm", sandstormInfo, {profile: {name: sandstormInfo.name}});
+            userInfo.userId = login.userId;
+          } else {
+            userInfo.userId = null;
+          }
+        } else {
+          // Since the app isn't using regular Meteor accounts, we can define Meteor.userId()
+          // however we want.
+          userInfo.userId = sandstormInfo.id;
+        }
+
+        future.return(userInfo);
+        res.writeHead(204, {});
+        res.end();
+      } catch (err) {
+        res.writeHead(500, {
+          "Content-Type": "text/plain"
+        });
+        res.end(err.stack);
+      }
+    });
   });
-});
+}


### PR DESCRIPTION
Fixes: #13

Moreover, for projects which still have to upgrade from 0.1 to 0.2 (like Rocket.Chat) this will allow to keep existing functionality. Because there is a breaking change now. 0.2 version logs out users always, even if Sandstorm is not activated. In 0.1 Sandstorm code was wrapped inside `if (!Meteor.userId())` so this did not happen. Now it does.

So without this improvement after upgrading people will get logged out every time. With this this will happen only when really using Sandstorm, and not just have its package.