### PR TITLE
decodeURI -> decodeURIComponent

### DIFF
--- a/server.js
+++ b/server.js
@@ -162,7 +162,7 @@ if (__meteor_runtime_config__.SANDSTORM) {
 
         var sandstormInfo = {
           id: req.headers["x-sandstorm-user-id"] || null,
-          name: decodeURI(req.headers["x-sandstorm-username"]),
+          name: decodeURIComponent(req.headers["x-sandstorm-username"]),
           permissions: permissions,
           picture: req.headers["x-sandstorm-user-picture"] || null,
           preferredHandle: req.headers["x-sandstorm-preferred-handle"] || null,


### PR DESCRIPTION
Currently, if a user's display is "wat?", meteor-accounts-sandstorm will save the name as "wat%3f", becuase `decodeURI()` does not decode question marks (nor commas nor some other characters). We should be using `decodeURIComponent()` instead.