### PR TITLE
Generate resume tokens, even though they cannot be used for login.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ In particular:
   returned by `Meteor.sandstormUser()`.
 * `Meteor.loggingIn()` will return `true` during the initial handshake (when
   `sandstormUser()` would return `null`).
+* For compatibility with libraries such as CollectionFS, "resume tokens" will be
+  generated and propagated to `localStorage["Meteor.loginToken"]`, matching the usual
+  Meteor login behavior. Note that Highlander mode intentionally prevents these tokens
+  from being usable for actually logging in.
 
 Please note, however, that you should prefer `sandstormUser()` over
 `Meteor.user().services.sandstorm` whenever possible, **especially** for enforcing

--- a/client.js
+++ b/client.js
@@ -75,6 +75,12 @@ function loginWithSandstorm(connection, apiHost, apiToken) {
       console.error("loginWithSandstorm failed:", error);
     } else {
       connection._sandstormUser.set(result.sandstorm);
+      if (Package["accounts-base"]) {
+        var resumeToken = result.resumeToken;
+        Package["accounts-base"].Accounts._storeLoginToken(
+          result.userId, resumeToken.token, resumeToken.when);
+      }
+
       connection.setUserId(result.userId);
     }
   };

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ if (process.env.SANDSTORM) {
 
 if (__meteor_runtime_config__.SANDSTORM) {
   if (Package["accounts-base"]) {
-    // Highlander Mode: Disable all non-Sandstorm login mechanisms.
+    // Highlander Mode: Disable all non-Sandstorm login mechanisms, including resume tokens.
     Package["accounts-base"].Accounts.validateLoginAttempt(function (attempt) {
       if (!attempt.allowed) {
         return false;
@@ -105,6 +105,14 @@ if (__meteor_runtime_config__.SANDSTORM) {
       this.connection._sandstormUser = info.sandstorm;
       this.connection._sandstormSessionId = info.sessionId;
       this.setUserId(info.userId);
+
+      if (Package["accounts-base"]) {
+        // CollectionFS (a common dependency in Meteor apps) relies on resume tokens to
+        // associate requests with users, so we generate a resume token here even though
+        // Highlander Mode disables using it to actually log in.
+        info.resumeToken = Accounts._generateStampedLoginToken();
+        Package["accounts-base"].Accounts._insertLoginToken(info.userId, info.resumeToken);
+      }
 
       return info;
     }


### PR DESCRIPTION
[This commit](https://github.com/wekan/wekan/commit/35c6b51a3f7fe878983620e6755ea35a1cf670c8) to Wekan caused attachment uploads to break when the app is run in Sandstorm. The problem is that CollectionFS [relies on resume tokens](https://github.com/CollectionFS/Meteor-CollectionFS/blob/868e0e0055590d2d8c55c00c4d347ae0f6bc6eb2/packages/access-point/access-point-server.js#L291-L338), and meteor-accounts-sandstorm v0.2 stopped providing resume tokens for Sandstorm users.

With this patch, we generate a resume token upon each login so that libraries like CollectionFS can use them. Highlander Mode prevents them from actually being used to successfully log in.